### PR TITLE
feat(wado-uri): Add function to create WADO-URI URL

### DIFF
--- a/build/dicomweb-client.js
+++ b/build/dicomweb-client.js
@@ -461,6 +461,38 @@
       return(this._httpGetApplicationJson(url));
     }
 
+    /** Returns a WADO-URI URL for an instance
+     *
+     * @param {Object} options
+     * @returns {String} WADO-URI URL
+     */
+    buildInstanceWadoURIUrl(options) {
+      if (!('studyInstanceUID' in options)) {
+        console.error('Study Instance UID is required.');
+      }
+      if (!('seriesInstanceUID' in options)) {
+        console.error('Series Instance UID is required.');
+      }
+      if (!('sopInstanceUID' in options)) {
+        console.error('SOP Instance UID is required.');
+      }
+
+      const contentType = options.contentType || 'application/dicom';
+      const transferSyntax = options.transferSyntax || '*';
+      const params = [];
+
+      params.push('requestType=WADO');
+      params.push(`studyUID=${options.studyInstanceUID}`);
+      params.push(`seriesUID=${options.seriesInstanceUID}`);
+      params.push(`objectUID=${options.sopInstanceUID}`);
+      params.push(`contentType=${contentType}`);
+      params.push(`transferSyntax=${transferSyntax}`);
+
+      const paramString = params.join('&');
+
+      return `${this.baseURL}?${paramString}`;
+    }
+
     /**
      * Retrieves metadata for a DICOM instance.
      * @param {String} studyInstanceUID Study Instance UID

--- a/src/api.js
+++ b/src/api.js
@@ -304,6 +304,38 @@ class DICOMwebClient {
     return(this._httpGetApplicationJson(url));
   }
 
+  /** Returns a WADO-URI URL for an instance
+   *
+   * @param {Object} options
+   * @returns {String} WADO-URI URL
+   */
+  buildInstanceWadoURIUrl(options) {
+    if (!('studyInstanceUID' in options)) {
+      console.error('Study Instance UID is required.')
+    }
+    if (!('seriesInstanceUID' in options)) {
+      console.error('Series Instance UID is required.')
+    }
+    if (!('sopInstanceUID' in options)) {
+      console.error('SOP Instance UID is required.')
+    }
+
+    const contentType = options.contentType || 'application/dicom';
+    const transferSyntax = options.transferSyntax || '*';
+    const params = [];
+
+    params.push('requestType=WADO');
+    params.push(`studyUID=${options.studyInstanceUID}`);
+    params.push(`seriesUID=${options.seriesInstanceUID}`);
+    params.push(`objectUID=${options.sopInstanceUID}`);
+    params.push(`contentType=${contentType}`);
+    params.push(`transferSyntax=${transferSyntax}`);
+
+    const paramString = params.join('&');
+
+    return `${this.baseURL}?${paramString}`;
+  }
+
   /**
    * Retrieves metadata for a DICOM instance.
    * @param {String} studyInstanceUID Study Instance UID


### PR DESCRIPTION
Moving this here from OHIF (https://github.com/OHIF/Viewers/blob/26b14f1dab62ece0232a8c1fae355bac38285695/Packages/ohif-studies/imports/both/services/wado/retrieveMetadata.js#L60)

Question: Should we allow more than one base URL? Some PACS use different endpoints for WADO-RS and WADO-URI?

Or should we move this function to some other place?