### PR TITLE
Error interceptor

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -71,8 +71,6 @@ class DICOMwebClient {
       this.stowURL = this.baseURL;
     }
 
-    debugger;
-
     this.headers = options.headers || {};
     this.errorInterceptor = options.errorInterceptor || function() {};
   }

--- a/src/api.js
+++ b/src/api.js
@@ -72,6 +72,7 @@ class DICOMwebClient {
     }
 
     this.headers = options.headers || {};
+    this.errorInterceptor = options.errorInterceptor || function() {};
   }
 
   static _parseQueryParameters(params = {}) {
@@ -135,6 +136,8 @@ class DICOMwebClient {
             error.status = request.status;
             console.error(error);
             console.error(error.response);
+
+            this.errorInterceptor(error);
 
             reject(error);
           }

--- a/src/api.js
+++ b/src/api.js
@@ -71,6 +71,8 @@ class DICOMwebClient {
       this.stowURL = this.baseURL;
     }
 
+    debugger;
+
     this.headers = options.headers || {};
     this.errorInterceptor = options.errorInterceptor || function() {};
   }
@@ -87,6 +89,9 @@ class DICOMwebClient {
   }
 
   _httpRequest(url, method, headers, options = {}) {
+
+    const {errorInterceptor} = this;
+
     return new Promise((resolve, reject) => {
       const request = new XMLHttpRequest();
       request.open(method, url, true);
@@ -137,7 +142,7 @@ class DICOMwebClient {
             console.error(error);
             console.error(error.response);
 
-            this.errorInterceptor(error);
+            errorInterceptor(error);
 
             reject(error);
           }

--- a/src/api.js
+++ b/src/api.js
@@ -71,7 +71,10 @@ class DICOMwebClient {
       this.stowURL = this.baseURL;
     }
 
+    // Headers to pass to requests.
     this.headers = options.headers || {};
+
+    // Optional error interceptor callback to handle any failed request.
     this.errorInterceptor = options.errorInterceptor || function() {};
   }
 


### PR DESCRIPTION
Allows the user to add an error interceptor so that a user may intercept and process a request error at the app level.

This pattern for a library avoids an application having to try/catch each call across the application, and makes centralizing error management easier.

This is in no way breaking and adds some new optional functionality. Error handling can be improved upon incrementally, but this adds something we can easily hit against for now. Happy to discuss.