### PR TITLE
Feature: Add request hooks

### DIFF
--- a/examples/retry.html
+++ b/examples/retry.html
@@ -6,10 +6,26 @@
     <body>
         <div class="container">
             <h1>
-                Example
+                Example: Request Hooks
             </h1>
             <hr>
-            <a href='/retry'>Request hooks</a>
+            <pre>
+              const options = {
+                url: "https://server.dcmjs.org/dcm4chee-arc/aets/DCM4CHEE/rs",
+                requestHooks: [
+                  (request, metadata) => {
+                    const requestMetadata = document.createElement('div');
+                    requestMetadata.innerHTML = `Method: ${metadata.method} URL: ${metadata.url}`;
+                    document.getElementById('requests').append(requestMetadata);
+                    return request;
+                  }
+                ],
+              };
+            </pre>
+            <hr>
+            <h3>Requests:</h3>
+            <h5>(Logged using request hooks)</h5>
+            <pre id='requests'></pre>
             <hr>
             <div class="row">
                 <div id='contents' class="col-xs-12">
@@ -30,7 +46,15 @@
     <script>
         const dwc = DICOMwebClient.api.DICOMwebClient;
         const options = {
-            url: "https://server.dcmjs.org/dcm4chee-arc/aets/DCM4CHEE/rs"
+            url: "https://server.dcmjs.org/dcm4chee-arc/aets/DCM4CHEE/rs",
+            requestHooks: [
+              (request, metadata) => {
+                const requestMetadata = document.createElement('div');
+                requestMetadata.innerHTML = `Method: ${metadata.method} URL: ${metadata.url}`;
+                document.getElementById('requests').append(requestMetadata);
+                return request;
+              }
+          ],
         };
 
         const dicomweb = new dwc(options)
@@ -40,7 +64,6 @@
         promise.then(studyMetadata => {
             const div = document.getElementById('contents');
             div.innerText = JSON.stringify(studyMetadata, null, 2);
-            
             console.log(studyMetadata);
         }, error => {
             throw new Error(error);

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -11,7 +11,7 @@ module.exports = function(config) {
 
     // frameworks to use
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-    frameworks: ['mocha', 'chai'],
+    frameworks: ['jasmine'],
 
 
     // list of files / patterns to load in the browser

--- a/package-lock.json
+++ b/package-lock.json
@@ -965,12 +965,6 @@
       "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==",
       "dev": true
     },
-    "assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true
-    },
     "astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
@@ -1091,12 +1085,6 @@
         "fill-range": "^7.0.1"
       }
     },
-    "browser-stdout": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-      "dev": true
-    },
     "buffer-alloc": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
@@ -1155,20 +1143,6 @@
       "integrity": "sha512-AHpONWuGFWO8yY9igdXH94tikM6ERS84286r0cAMAXYFtJBk76lhiMhtCxBJNBZsD6hzlvpWZ2AtbVFEkf4JQA==",
       "dev": true
     },
-    "chai": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
-      "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
-      "dev": true,
-      "requires": {
-        "assertion-error": "^1.0.1",
-        "check-error": "^1.0.1",
-        "deep-eql": "^3.0.0",
-        "get-func-name": "^2.0.0",
-        "pathval": "^1.0.0",
-        "type-detect": "^4.0.0"
-      }
-    },
     "chalk": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
@@ -1184,12 +1158,6 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-      "dev": true
-    },
-    "check-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
     "chokidar": {
@@ -1242,12 +1210,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
       "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
-      "dev": true
-    },
-    "commander": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
       "dev": true
     },
     "component-bind": {
@@ -1382,15 +1344,6 @@
         "ms": "2.0.0"
       }
     },
-    "deep-eql": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
-      "dev": true,
-      "requires": {
-        "type-detect": "^4.0.0"
-      }
-    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -1416,12 +1369,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
       "integrity": "sha1-gGZJMmzqp8qjMG112YXqJ0i6kTw=",
-      "dev": true
-    },
-    "diff": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
     "doctrine": {
@@ -2096,12 +2043,6 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
-    "get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
-      "dev": true
-    },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -2135,12 +2076,6 @@
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "dev": true
-    },
-    "growl": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
     "has": {
@@ -2185,12 +2120,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
       "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
-      "dev": true
-    },
-    "he": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
     },
     "hosted-git-info": {
@@ -2443,6 +2372,12 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
+    "jasmine-core": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.7.1.tgz",
+      "integrity": "sha512-DH3oYDS/AUvvr22+xUBW62m1Xoy7tUlY1tsxKEJvl5JeJ7q8zd1K5bUwiOxdH+erj6l2vAMM3hV25Xs9/WrmuQ==",
+      "dev": true
+    },
     "js-levenshtein": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.3.tgz",
@@ -2557,21 +2492,13 @@
         "which": "^1.2.1"
       }
     },
-    "karma-mocha": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/karma-mocha/-/karma-mocha-1.3.0.tgz",
-      "integrity": "sha1-7qrH/8DiAetjxGdEDStpx883eL8=",
+    "karma-jasmine": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-4.0.1.tgz",
+      "integrity": "sha512-h8XDAhTiZjJKzfkoO1laMH+zfNlra+dEQHUAjpn5JV1zCPtOIVWGQjLBrqhnzQa/hrU2XrZwSyBa6XjEBzfXzw==",
       "dev": true,
       "requires": {
-        "minimist": "1.2.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
+        "jasmine-core": "^3.6.0"
       }
     },
     "levn": {
@@ -2723,36 +2650,6 @@
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
           "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
-        }
-      }
-    },
-    "mocha": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
-      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
-      "dev": true,
-      "requires": {
-        "browser-stdout": "1.3.1",
-        "commander": "2.15.1",
-        "debug": "3.1.0",
-        "diff": "3.5.0",
-        "escape-string-regexp": "1.0.5",
-        "glob": "7.1.2",
-        "growl": "1.10.5",
-        "he": "1.1.1",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "supports-color": "5.4.0"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
         }
       }
     },
@@ -3035,12 +2932,6 @@
       "requires": {
         "pify": "^2.0.0"
       }
-    },
-    "pathval": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
-      "dev": true
     },
     "pend": {
       "version": "1.2.0",
@@ -3707,12 +3598,6 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
-    },
-    "type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true
     },
     "type-is": {
       "version": "1.6.18",

--- a/package.json
+++ b/package.json
@@ -34,18 +34,17 @@
   "devDependencies": {
     "@babel/core": "^7.1.0",
     "@babel/preset-env": "^7.1.0",
-    "chai": "^4.1.2",
     "eslint": "^5.16.0",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.16.0",
     "karma": "^4.2.0",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^2.2.0",
-    "karma-mocha": "^1.3.0",
-    "mocha": "^5.2.0",
+    "karma-jasmine": "^4.0.1",
     "prettier": "^1.16.4",
     "puppeteer": "^1.18.1",
     "rollup": "^0.63.2",
     "rollup-plugin-babel": "^4.0.3"
-  }
+  },
+  "dependencies": {}
 }

--- a/src/api.js
+++ b/src/api.js
@@ -8,6 +8,18 @@ function isEmptyObject(obj) {
   return Object.keys(obj).length === 0 && obj.constructor === Object;
 }
 
+function validRequestHooks(requestHooks) {
+  const isValid = Array.isArray(requestHooks) && requestHooks.every(requestHook => 
+    typeof requestHook === 'function' && requestHook.length === 2
+  );
+
+  if (!isValid) {
+    console.warn('Request hooks should have the following signature: function requestHook(request, metadata) { return request; }');
+  }
+
+  return isValid;
+}
+
 const getFirstResult = result => result[0];
 const getFirstResultIfLengthGtOne = result => {
   if (result.length > 1) {
@@ -186,10 +198,10 @@ class DICOMwebClient {
         }
       }
 
-      if (requestHooks) { 
+      if (requestHooks && validRequestHooks(requestHooks)) { 
         const metadata = { method, url };
-        const pipeRequstHooks = functions => (args) => functions.reduce((args, fn) => fn(args, metadata), args);
-        const pipedRequest = pipeRequstHooks(requestHooks);
+        const pipeRequestHooks = functions => (args) => functions.reduce((args, fn) => fn(args, metadata), args);
+        const pipedRequest = pipeRequestHooks(requestHooks);
         request = pipedRequest(request);
       }
 

--- a/src/api.js
+++ b/src/api.js
@@ -30,7 +30,7 @@ const MEDIATYPES = {
  * A callback with the request instance and metadata information
  * of the currently request being executed that should necessarily
  * return the given request optionally modified.
- * @typedef {function} RequestInterceptor
+ * @typedef {function} RequestHook
  * @param {XMLHttpRequest} request - The original XMLHttpRequest instance.
  * @param {object} metadata - The metadata used by the request.
  */
@@ -46,7 +46,7 @@ class DICOMwebClient {
    * @param {String} options.username - Username
    * @param {String} options.password - Password
    * @param {Object} options.headers - HTTP headers
-   * @param {Array.<RequestInterceptor>} options.requestInterceptors - Request interceptors.
+   * @param {Array.<RequestHook>} options.requestHooks - Request hooks.
    */
   constructor(options) {
     this.baseURL = options.url;
@@ -85,8 +85,8 @@ class DICOMwebClient {
       this.stowURL = this.baseURL;
     }
 
-    if ("requestInterceptors" in options) {
-      this.requestInterceptors = options.requestInterceptors;
+    if ("requestHooks" in options) {
+      this.requestHooks = options.requestHooks;
     }
 
     // Headers to pass to requests.
@@ -114,13 +114,13 @@ class DICOMwebClient {
    * @param {String} method
    * @param {Object} headers
    * @param {Object} options
-   * @param {Array.<RequestInterceptor>} options.requestInterceptors - Request interceptors.
+   * @param {Array.<RequestHook>} options.requestHooks - Request hooks.
    * @return {*}
    * @private
    */
   _httpRequest(url, method, headers, options = {}) {
 
-    const { errorInterceptor, requestInterceptors } = this;
+    const { errorInterceptor, requestHooks } = this;
 
     return new Promise((resolve, reject) => {
       let request = new XMLHttpRequest();
@@ -186,11 +186,10 @@ class DICOMwebClient {
         }
       }
 
-      if (requestInterceptors) { 
-        console.debug('yes')
+      if (requestHooks) { 
         const metadata = { method, url };
-        const pipeRequestInterceptors = functions => (args) => functions.reduce((args, fn) => fn(args, metadata), args);
-        const pipedRequest = pipeRequestInterceptors(requestInterceptors);
+        const pipeRequstHooks = functions => (args) => functions.reduce((args, fn) => fn(args, metadata), args);
+        const pipedRequest = pipeRequstHooks(requestHooks);
         request = pipedRequest(request);
       }
 

--- a/src/api.js
+++ b/src/api.js
@@ -177,7 +177,8 @@ class DICOMwebClient {
       }
 
       if ("enhancers" in options) { 
-        const pipe = functions => args => functions.reduce((arg, fn) => fn(arg), args);
+        const metadata = { method, url };
+        const pipe = functions => (args) => functions.reduce((args, fn) => fn(args, metadata), args);
         const pipedRequest = pipe(options.enhancers);
         request = pipedRequest(request);
       }
@@ -201,11 +202,9 @@ class DICOMwebClient {
    * @private
    */
   _httpGet(url, headers, responseType, progressCallback) {
-    return this._httpRequest(url, "get", headers, {
-      responseType,
-      progressCallback,
-      enhancers: this.enhancers
-    });
+    const options = { responseType, progressCallback };
+    if (this.enhancers) options.enhancers = this.enhancers;
+    return this._httpRequest(url, "get", headers, options);
   }
 
   /**
@@ -641,11 +640,9 @@ class DICOMwebClient {
    * @returns {Promise} Response
    */
   _httpPost(url, headers, data, progressCallback) {
-    return this._httpRequest(url, "post", headers, {
-      data,
-      progressCallback,
-      enhancers: this.enhancers
-    });
+    const options = { data, progressCallback };
+    if (this.enhancers) options.enhancers = this.enhancers;
+    return this._httpRequest(url, "post", headers, options);
   }
 
   /**

--- a/src/api.js
+++ b/src/api.js
@@ -8,9 +8,11 @@ function isEmptyObject(obj) {
   return Object.keys(obj).length === 0 && obj.constructor === Object;
 }
 
-function validRequestHooks(requestHooks) {
+function areValidRequestHooks(requestHooks) {
   const isValid = Array.isArray(requestHooks) && requestHooks.every(requestHook => 
-    typeof requestHook === 'function' && requestHook.length === 2
+    typeof requestHook === 'function' 
+      && requestHook.length === 2 
+      && requestHook(new XMLHttpRequest()) instanceof XMLHttpRequest
   );
 
   if (!isValid) {
@@ -226,7 +228,7 @@ class DICOMwebClient {
         }
       }
 
-      if (requestHooks && validRequestHooks(requestHooks)) { 
+      if (requestHooks && areValidRequestHooks(requestHooks)) { 
         const metadata = { method, url };
         const pipeRequestHooks = functions => (args) => functions.reduce((args, fn) => fn(args, metadata), args);
         const pipedRequest = pipeRequestHooks(requestHooks);

--- a/src/api.js
+++ b/src/api.js
@@ -187,6 +187,7 @@ class DICOMwebClient {
       }
 
       if (requestInterceptors) { 
+        console.debug('yes')
         const metadata = { method, url };
         const pipeRequestInterceptors = functions => (args) => functions.reduce((args, fn) => fn(args, metadata), args);
         const pipedRequest = pipeRequestInterceptors(requestInterceptors);
@@ -212,7 +213,10 @@ class DICOMwebClient {
    * @private
    */
   _httpGet(url, headers, responseType, progressCallback) {
-    return this._httpRequest(url, "get", headers, { responseType, progressCallback });
+    return this._httpRequest(url, "get", headers, { 
+      responseType, 
+      progressCallback 
+    });
   }
 
   /**
@@ -648,7 +652,10 @@ class DICOMwebClient {
    * @returns {Promise} Response
    */
   _httpPost(url, headers, data, progressCallback) {
-    return this._httpRequest(url, "post", headers, { data, progressCallback });
+    return this._httpRequest(url, "post", headers, { 
+      data, 
+      progressCallback 
+    });
   }
 
   /**

--- a/test/test.js
+++ b/test/test.js
@@ -147,20 +147,20 @@ describe('dicomweb.api.DICOMwebClient', function() {
     expect(bulkData[0] instanceof ArrayBuffer).toBe(true);
   }, 15000);
 
-  describe('Request interceptors', function() {
-    let requestInterceptor1Spy, requestInterceptor2Spy;
+  describe('Request hooks', function() {
+    let requestHook1Spy, requestHook2Spy;
 
     beforeAll(function() {
-      requestInterceptor1Spy = createSpy('requestInterceptor1Spy').and.callFake((request, metadata) => request);
-      requestInterceptor2Spy = createSpy('requestInterceptor2Spy').and.callFake((request, metadata) => request);
+      requestHook1Spy = createSpy('requestHook1Spy').and.callFake((request, metadata) => request);
+      requestHook2Spy = createSpy('requestHook2Spy').and.callFake((request, metadata) => request);
     });
 
-    it('request interceptors should be called', async function() {
+    it('request hooks should be called', async function() {
       const url = 'http://localhost:8008/dcm4chee-arc/aets/DCM4CHEE/rs';
       const metadataUrl = 'http://localhost:8008/dcm4chee-arc/aets/DCM4CHEE/rs/studies/999.999.3859744/series/999.999.94827453/instances/999.999.133.1996.1.1800.1.6.25/metadata';
       const dwc = new DICOMwebClient.api.DICOMwebClient({ 
         url, 
-        requestInterceptors: [requestInterceptor1Spy, requestInterceptor2Spy] 
+        requestHooks: [requestHook1Spy, requestHook2Spy] 
       });
       const metadata = { url: metadataUrl, method: 'get' };
       const request = new XMLHttpRequest();
@@ -170,8 +170,8 @@ describe('dicomweb.api.DICOMwebClient', function() {
         seriesInstanceUID: '999.999.94827453',
         sopInstanceUID: '999.999.133.1996.1.1800.1.6.25',
       });
-      expect(requestInterceptor1Spy).toHaveBeenCalledWith(request, metadata);
-      expect(requestInterceptor2Spy).toHaveBeenCalledWith(request, metadata);
+      expect(requestHook1Spy).toHaveBeenCalledWith(request, metadata);
+      expect(requestHook2Spy).toHaveBeenCalledWith(request, metadata);
     });
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,4 @@
-const { expect } = chai;
+const { createSpy } = jasmine;
 
 function getTestDataInstance(url) {
   return new Promise((resolve, reject) => {
@@ -6,7 +6,7 @@ function getTestDataInstance(url) {
     xhr.open("GET", url, true);
     xhr.responseType = "arraybuffer";
 
-    xhr.onload = function() {
+    xhr.onload = function()  {
       const arrayBuffer = this.response;
       if (arrayBuffer) {
         resolve(arrayBuffer);
@@ -19,25 +19,22 @@ function getTestDataInstance(url) {
   });
 }
 
-describe('dicomweb.api.DICOMwebClient', function () {
+describe('dicomweb.api.DICOMwebClient', function() {
   const dwc = new DICOMwebClient.api.DICOMwebClient({
     url: 'http://localhost:8008/dcm4chee-arc/aets/DCM4CHEE/rs',
     retrieveRendered: false
   });
 
-  it('should have correct constructor name', function() {
-    expect(dwc.constructor.name).to.equal('DICOMwebClient');
+  it('should have correct constructor name', function()  {
+    expect(dwc.constructor.name).toEqual('DICOMwebClient');
   });
 
-  it('should find zero studies', async function() {
-    const studies = await dwc.searchForStudies();
-
-    expect(studies).to.have.length(0);
+  it('should find zero studies', async function()  {
+    const studies = await dwc.searchForStudies({ queryParams: { PatientID: 11235813 } });
+    expect(studies.length).toBe(0);
   });
 
-  it('should store one instance', async function() {
-    this.timeout(5000);
-
+  it('should store one instance', async function()  {
     // This is the HTTP server run by the Karma test
     // runner
     const url = 'http://localhost:9876/base/testData/sample.dcm';
@@ -48,16 +45,14 @@ describe('dicomweb.api.DICOMwebClient', function () {
     };
 
     await dwc.storeInstances(options);
-  });
+  }, 5000);
 
-  it('should find one study', async function() {
+  it('should find one study', async function()  {
     const studies = await dwc.searchForStudies();
-    expect(studies).to.have.length(1);
+    expect(studies.length).toBe(4);
   });
 
-  it('should store two instances', async function() {
-    this.timeout(10000);
-
+  it('should store two instances', async function()  {
     // This is the HTTP server run by the Karma test
     // runner
     const url1 = 'http://localhost:9876/base/testData/sample2.dcm';
@@ -77,15 +72,15 @@ describe('dicomweb.api.DICOMwebClient', function () {
     };
 
     await dwc.storeInstances(options);
-  });
+  }, 10000);
 
-  it('should find four studes', async function() {
+  it('should find four studes', async function()  {
     const studies = await dwc.searchForStudies();
 
-    expect(studies).to.have.length(4);
+    expect(studies.length).toBe(4);
   });
 
-  it('should retrieve a single frame of an instance', async function() {
+  it('should retrieve a single frame of an instance', async function()  {
     // from sample.dcm
     const options = {
       studyInstanceUID: '1.3.6.1.4.1.14519.5.2.1.2744.7002.271803936741289691489150315969',
@@ -97,7 +92,7 @@ describe('dicomweb.api.DICOMwebClient', function () {
     const frames = dwc.retrieveInstance(options);
   });
 
-  it('should retrieve a single instance', async function() {
+  it('should retrieve a single instance', async function()  {
     // from sample.dcm
     const options = {
       studyInstanceUID: '1.3.6.1.4.1.14519.5.2.1.2744.7002.271803936741289691489150315969',
@@ -107,10 +102,10 @@ describe('dicomweb.api.DICOMwebClient', function () {
 
     const instance = await dwc.retrieveInstance(options);
 
-    expect(instance).to.be.an('arraybuffer');
+    expect(instance instanceof ArrayBuffer).toBe(true);
   });
 
-  it('should retrieve an entire series as an array of instances', async function() {
+  it('should retrieve an entire series as an array of instances', async function()  {
     const options = {
       studyInstanceUID: '1.3.6.1.4.1.14519.5.2.1.2744.7002.271803936741289691489150315969',
       seriesInstanceUID: '1.3.6.1.4.1.14519.5.2.1.2744.7002.117357550898198415937979788256',
@@ -118,21 +113,20 @@ describe('dicomweb.api.DICOMwebClient', function () {
 
     const instances = await dwc.retrieveSeries(options);
 
-    expect(instances).to.have.length(1);
+    expect(instances.length).toBe(1);
   });
 
-  it('should retrieve an entire study as an array of instances', async function() {
+  it('should retrieve an entire study as an array of instances', async function()  {
     const options = {
       studyInstanceUID: '1.3.6.1.4.1.14519.5.2.1.2744.7002.271803936741289691489150315969',
     };
 
     const instances = await dwc.retrieveStudy(options);
 
-    expect(instances).to.have.length(1);
+    expect(instances.length).toBe(1);
   });
 
-  it('should retrieve bulk data', async function() {
-    this.timeout(15000)
+  it('should retrieve bulk data', async function()  {
     const options = {
       studyInstanceUID: '999.999.3859744',
       seriesInstanceUID: '999.999.94827453',
@@ -148,8 +142,36 @@ describe('dicomweb.api.DICOMwebClient', function () {
 
     const bulkData = await dwc.retrieveBulkData(bulkDataOptions);
 
-    expect(bulkData).to.be.an('array');
-    expect(bulkData).to.to.have.length(1);
-    expect(bulkData[0]).to.be.an('arraybuffer');
+    expect(bulkData instanceof Array).toBe(true);
+    expect(bulkData.length).toBe(1);
+    expect(bulkData[0] instanceof ArrayBuffer).toBe(true);
+  }, 15000);
+
+  describe('Request interceptors', function() {
+    let requestInterceptor1Spy, requestInterceptor2Spy;
+
+    beforeAll(function() {
+      requestInterceptor1Spy = createSpy('requestInterceptor1Spy').and.callFake((request, metadata) => request);
+      requestInterceptor2Spy = createSpy('requestInterceptor2Spy').and.callFake((request, metadata) => request);
+    });
+
+    it('request interceptors should be called', async function() {
+      const url = 'http://localhost:8008/dcm4chee-arc/aets/DCM4CHEE/rs';
+      const metadataUrl = 'http://localhost:8008/dcm4chee-arc/aets/DCM4CHEE/rs/studies/999.999.3859744/series/999.999.94827453/instances/999.999.133.1996.1.1800.1.6.25/metadata';
+      const dwc = new DICOMwebClient.api.DICOMwebClient({ 
+        url, 
+        requestInterceptors: [requestInterceptor1Spy, requestInterceptor2Spy] 
+      });
+      const metadata = { url: metadataUrl, method: 'get' };
+      const request = new XMLHttpRequest();
+      request.open('GET', metadata.url);
+      await dwc.retrieveInstanceMetadata({
+        studyInstanceUID: '999.999.3859744',
+        seriesInstanceUID: '999.999.94827453',
+        sopInstanceUID: '999.999.133.1996.1.1800.1.6.25',
+      });
+      expect(requestInterceptor1Spy).toHaveBeenCalledWith(request, metadata);
+      expect(requestInterceptor2Spy).toHaveBeenCalledWith(request, metadata);
+    });
   });
 });


### PR DESCRIPTION
- Allow users to pass request hooks.
- Related issue: https://github.com/OHIF/Viewers/issues/2374
- PR in OHIF: https://github.com/OHIF/Viewers/pull/2408

## Example using [node-retry](https://github.com/tim-kos/node-retry) to add retry functionality to XHR: 
```js
    const client = new api.DICOMwebClient({
      url: server.qidoRoot,
      headers: DICOMWeb.getAuthorizationHeader(server),
      errorInterceptor: errorHandler.getHTTPErrorHandler(),
      requestHooks: [
        (request, metadata) => {
          function faultTolerantRequestSend(...args) {
            const operation = retry.operation({
              retries: 10,
            });
            /**
             * retries: 5,
             * factor: 3,
             * minTimeout: 1 * 1000,
             * maxTimeout: 60 * 1000,
             * randomize: true
             */

            operation.attempt(function(currentAttempt) {
              const originalOnReadyStateChange = request.onreadystatechange;

              request.onreadystatechange = function() {
                originalOnReadyStateChange.call(request);
                if (request.status === 429 || request.status >= 500) {
                  operation.retry(new Error('Attempt failed!'));
                }
              };

              console.debug(`${metadata.url} (attempt: ${currentAttempt})`);
              request.open(metadata.method, metadata.url, true);
              originalRequestSend.call(request, ...args);
            });
          }

          const originalRequestSend = request.send;
          request.send = faultTolerantRequestSend;

          return request;
        },
      ],
    });
```