### PR TITLE
Request Hooks: Remove runtime check for return type

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -12,7 +12,6 @@ function areValidRequestHooks(requestHooks) {
   const isValid = Array.isArray(requestHooks) && requestHooks.every(requestHook => 
     typeof requestHook === 'function' 
       && requestHook.length === 2 
-      && requestHook(new XMLHttpRequest()) instanceof XMLHttpRequest
   );
 
   if (!isValid) {


### PR DESCRIPTION
- Adding a runtime check for return type has a side-effect: it executes the original function. Until we find a better way to runtime check return types without typescript this should be removed.