### PR TITLE
Expose headers for request hooks

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -156,12 +156,13 @@ class DICOMwebClient {
    * @return {*}
    * @private
    */
-  _httpRequest(url, method, headers, options = {}) {
+  _httpRequest(url, method, headers = {}, options = {}) {
 
     const { errorInterceptor, requestHooks } = this;
 
     return new Promise((resolve, reject) => {
       let request = new XMLHttpRequest();
+
       request.open(method, url, true);
       if ("responseType" in options) {
         request.responseType = options.responseType;
@@ -231,7 +232,8 @@ class DICOMwebClient {
       }
 
       if (requestHooks && areValidRequestHooks(requestHooks)) { 
-        const metadata = { method, url };
+        const headers = Object.assign({}, headers, this.headers);
+        const metadata = { method, url, headers };
         const pipeRequestHooks = functions => (args) => functions.reduce((args, fn) => fn(args, metadata), args);
         const pipedRequest = pipeRequestHooks(requestHooks);
         request = pipedRequest(request);


### PR DESCRIPTION
Expose request and headers provided by options to request hooks.
Note: The headers option is exposed to request hooks but is not directly attached to the XHR request.

### Use case: request cancellation.
- A custom header attribute is added to the request using the headers option in order to tag each request.
- Later this header attribute containing the tag is accessed through the metadata parameter inside a request hook in order to identify and abort the request if needed (user interacts with the viewer and all requests made for a specific tag are not needed).