### PR TITLE
fix(#39) make the test script testable on Mac OSX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ yarn.lock
 .env
 
 .idea
+
+# docker files created by the docker containers for testing
+tmp

--- a/dcm4chee-docker-compose.yml
+++ b/dcm4chee-docker-compose.yml
@@ -10,8 +10,8 @@ services:
       - "389"
     env_file: dcm4chee-docker-compose.env
     volumes:
-      - /tmp/dcm4chee-arc/ldap:/var/lib/ldap
-      - /tmp/dcm4chee-arc/slapd.d:/etc/ldap/slapd.d
+      - ./tmp/dcm4chee-arc/ldap:/var/lib/ldap
+      - ./tmp/dcm4chee-arc/slapd.d:/etc/ldap/slapd.d
   db:
     image: dcm4che/postgres-dcm4chee:10.0-13
     logging:
@@ -22,7 +22,7 @@ services:
       - "5432"
     env_file: dcm4chee-docker-compose.env
     volumes:
-      - /tmp/dcm4chee-arc/db:/var/lib/postgresql/data
+      - ./tmp/dcm4chee-arc/db:/var/lib/postgresql/data
   arc:
     image: dcm4che/dcm4chee-arc-psql:5.13.3
     logging:
@@ -39,5 +39,5 @@ services:
       - ldap
       - db
     volumes:
-      - /tmp/dcm4chee-arc/wildfly:/opt/wildfly/standalone
-      - /tmp/dcm4chee-arc/storage:/storage
+      - ./tmp/dcm4chee-arc/wildfly:/opt/wildfly/standalone
+      - ./tmp/dcm4chee-arc/storage:/storage

--- a/test/test.js
+++ b/test/test.js
@@ -72,7 +72,7 @@ describe('dicomweb.api.DICOMwebClient', function() {
     };
 
     await dwc.storeInstances(options);
-  }, 10000);
+  }, 20000);
 
   it('should find four studes', async function()  {
     const studies = await dwc.searchForStudies();
@@ -165,7 +165,7 @@ describe('dicomweb.api.DICOMwebClient', function() {
         url, 
         requestHooks: [requestHook1Spy, requestHook2Spy] 
       });
-      const metadata = { url: metadataUrl, method: 'get' };
+      const metadata = { url: metadataUrl, method: 'get', headers: {} };
       request.open('GET', metadata.url);
       await dwc.retrieveInstanceMetadata({
         studyInstanceUID: '999.999.3859744',
@@ -181,7 +181,7 @@ describe('dicomweb.api.DICOMwebClient', function() {
         url, 
         requestHooks: [requestHook1Spy, requestHook2Spy] 
       });
-      const metadata = { url: metadataUrl, method: 'get' };
+      const metadata = { url: metadataUrl, method: 'get', headers: {}  };
       request.open('GET', metadata.url);
       await dwc.retrieveInstanceMetadata({
         studyInstanceUID: '999.999.3859744',


### PR DESCRIPTION
Hi, this pull request is fix for the fix(#39) make the test script testable on Mac OSX.

1) change the docker-compose script so that the working directory is created under the working directory and add the directory to the .gitignore.
2) fix issues in the two test cases
   -  Add empty header object to the metadata.
   -  Extend the run duration from 10,000ms to 20,000ms