### PR TITLE
fix(dicomweb-client):Make the retrieveBulkData handle either single or multipart responses.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ client.searchForStudies().then(studies => {
 });
 ```
 
+## Configuration Options
+The API can be configured with a number of custom configuration options to control the requests.  These are:
+* url to retrieve from for the base requests
+* singlepart, either true or a set of parts from `bulkdata,image,video` to request as single part responses
+* headers to add to the retrieve
 
 ## For maintainers
 

--- a/src/message.js
+++ b/src/message.js
@@ -184,7 +184,8 @@ function multipartEncode(
  * @returns {Array} The content
  */
 function multipartDecode(response) {
-  const message = new Uint8Array(response);
+  // Use the raw data if it is provided in an appropriate format
+  const message = ArrayBuffer.isView(response) ? response : new Uint8Array(response);
 
   /* Set a maximum length to search for the header boundaries, otherwise
        findToken can run for a long time


### PR DESCRIPTION
The DICOMweb standard can be interpreted in a few ways, one of which is that BulkDataURI always returns single part bulk data when requested as a full URL.  This interpretation doesn't work for the existing retrieveBulkDataURI, so the library has been updated to allow retrieving as either single or multipart, letting the server decide how to return the data.