### PR TITLE
corrected _getSharedMediaTypes to enable methods like retrieveStudy w…

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -896,8 +896,13 @@ class DICOMwebClient {
 
     mediaTypes.forEach((item) => {
       const { mediaType } = item;
-      const type = DICOMwebClient._parseMediaType(mediaType)[0];
-      types.add(`${type}/`);
+      if (mediaType.startsWith("application")) {
+        types.add(mediaType);
+      } else {
+        const type = DICOMwebClient._parseMediaType(mediaType)[0];
+
+        types.add(`${type}/`);
+      }
     });
 
     return Array.from(types);


### PR DESCRIPTION
…hich check for commonMediaType === MEDIATYPES.DICOM


Problem description:
Some functions like "retrieveStudy(options)" check for commonMediaType === MEDIATYPES.DICOM and throw "Media type ${commonMediaType} is not supported for retrieval of study." when the condition is not met.

Current implementation of _getSharedMediaTypes returns "application/" for "application/dicom" which will not meet the condition above.

With the modification that I have introduced, "application/dicom" will stay intact. 

Please note: There was something similar in previous versions of this code.   