### PR TITLE
fix(api): change JSDocs on mediaType param to reflect code

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1268,6 +1268,12 @@ class DICOMwebClient {
     );
   }
 
+ /**
+ * Element in mediaTypes parameter
+ * @typedef {Object} MediaType
+ * @param {String} [MediaType.mediaType] - ie 'image/jpeg', 'image/png'...
+ */
+
   /**
    * Retrieves an individual, server-side rendered DICOM Instance.
    *
@@ -1275,7 +1281,7 @@ class DICOMwebClient {
    * @param {String} options.studyInstanceUID - Study Instance UID
    * @param {String} options.seriesInstanceUID - Series Instance UID
    * @param {String} options.sopInstanceUID - SOP Instance UID
-   * @param {String[]} [options.mediaType] - Acceptable HTTP media types
+   * @param {MediaType[]} [options.mediaTypes] - Acceptable HTTP media types
    * @param {Object} [options.queryParams] - HTTP query parameters
    * @returns {Promise<ArrayBuffer>} Rendered DICOM Instance
    */
@@ -1354,7 +1360,7 @@ class DICOMwebClient {
    * @param {String} options.studyInstanceUID - Study Instance UID
    * @param {String} options.seriesInstanceUID - Series Instance UID
    * @param {String} options.sopInstanceUID - SOP Instance UID
-   * @param {String[]} [options.mediaType] - Acceptable HTTP media types
+   * @param {MediaType[]} [options.mediaTypes] - Acceptable HTTP media types
    * @param {Object} [options.queryParams] - HTTP query parameters
    * @returns {ArrayBuffer} Thumbnail
    */
@@ -1424,7 +1430,7 @@ class DICOMwebClient {
    * @param {String} options.seriesInstanceUID - Series Instance UID
    * @param {String} options.sopInstanceUID - SOP Instance UID
    * @param {String} options.frameNumbers - One-based indices of Frame Items
-   * @param {String[]} [options.mediaType] - Acceptable HTTP media types
+   * @param {MediaType[]} [options.mediaTypes] - Acceptable HTTP media types
    * @param {Object} [options.queryParams] - HTTP query parameters
    * @returns {ArrayBuffer[]} Rendered Frame Items as byte arrays
    */


### PR DESCRIPTION
Changes:
* Option object key name mediaType -> mediaTypes
* MediaType is an object with `mediaType` key, not a String