### PR TITLE
feat(api): replaced upload callbacks and abort signal with an HTTP request object

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,41 @@ client.searchForStudies().then(studies => {
 });
 ```
 
+An optional, custom `XMLHttpRequest` can be passed to `storeInstances` as a property of the `options` parameter. When present, instead of creating a new `XMLHttpRequest` instance, the passed instance is used instead. One use of this would be to track the progress of a DICOM store and/or cancel it. 
+
+See the js snippet below for an example of where the upload's percentage progress is output to the console.
+
+```js
+const url = 'http://localhost:8080/dicomweb';
+const client = new DICOMwebClient.api.DICOMwebClient({url});
+
+// an ArrayBuffer of the DICOM object/file
+const dataSet = ... ; 
+
+// A custom HTTP request
+const request = new XMLHttpRequest();
+
+// A callback that outputs the percentage complete to the console.
+const progressCallback = evt => {
+  if (!evt.lengthComputable) {
+    // Progress computation is not possible.
+    return;
+  }
+
+  const percentComplete = Math.round((100 * evt.loaded) / evt.total);
+  console.log("storeInstances  is " + percentComplete + "%");
+};
+
+// Add the progress callback as a listener to the request upload object.
+request.upload.addEventListener('progress', progressCallback);
+
+const storeInstancesOptions = {
+  dataSets,
+  request,
+}
+client.storeInstances(storeInstancesOptions).then( () => console.log("storeInstances completed successfully.") );
+
+```
 
 ## For maintainers
 

--- a/src/api.js
+++ b/src/api.js
@@ -152,7 +152,6 @@ class DICOMwebClient {
    * @param {Object} headers
    * @param {Object} options
    * @param {Array.<RequestHook>} options.requestHooks - Request hooks.
-   * @param {Object} [options.abortSignal] - an AbortController.AbortSignal object to listen for abort requests
    * @return {*}
    * @private
    */
@@ -228,27 +227,6 @@ class DICOMwebClient {
         if (typeof options.progressCallback === 'function') {
           request.onprogress = options.progressCallback;
         }
-      }
-
-      if ('abortSignal' in options && options.abortSignal) {
-        const { abortSignal } = options;
-
-        if(abortSignal.aborted) {
-          request.abort();
-          reject(new Error('The request was aborted.'));
-          return;
-        }
-
-        const abortCallback = () => request.abort();
-         
-        abortSignal.addEventListener('abort', abortCallback);
-
-        const removeAbortListener = () => {
-          abortSignal.removeEventListener('abort', abortCallback);
-          request.removeEventListener('loadend', removeAbortListener);
-        };
-
-        request.addEventListener('loadend', removeAbortListener);
       }
 
       if (requestHooks && areValidRequestHooks(requestHooks)) {
@@ -731,16 +709,14 @@ class DICOMwebClient {
    * @param {Object} headers - HTTP header fields
    * @param {Array} data - Data that should be stored
    * @param {Function} progressCallback
-   * @param {Object} abortSignal - an AbortController.AbortSignal object to listen for abort requests
    * @private
    * @returns {Promise} Response
    */
-  _httpPost(url, headers, data, progressCallback, withCredentials, abortSignal) {
+  _httpPost(url, headers, data, progressCallback, withCredentials) {
     return this._httpRequest(url, 'post', headers, {
       data,
       progressCallback,
       withCredentials,
-      abortSignal,
     });
   }
 
@@ -1793,7 +1769,6 @@ class DICOMwebClient {
    * @param {Object} options
    * @param {ArrayBuffer[]} options.datasets - DICOM Instances in PS3.10 format
    * @param {String} [options.studyInstanceUID] - Study Instance UID
-   * @param {Object} [options.abortSignal] - an AbortController.AbortSignal object to listen for abort requests
    * @returns {Promise} Response message
    */
   storeInstances(options) {
@@ -1812,7 +1787,7 @@ class DICOMwebClient {
     };
     const { withCredentials = false } = options;
     return this._httpPost(
-      url, headers, data, options.progressCallback, withCredentials, options.abortSignal
+      url, headers, data, options.progressCallback, withCredentials,
     );
   }
 }

--- a/src/api.js
+++ b/src/api.js
@@ -152,14 +152,6 @@ class DICOMwebClient {
    * @param {Object} headers
    * @param {Object} options
    * @param {Array.<RequestHook>} options.requestHooks - Request hooks.
-   * @param {Object} [options.uploadCallbacks] - various listeners for the XMLHttpRequest.upload object
-   * @param {Function} [options.uploadCallbacks.loadstart] - listener for upload start event
-   * @param {Function} [options.uploadCallbacks.progress] - listener for upload progress event
-   * @param {Function} [options.uploadCallbacks.abort] - listener for upload aborted event
-   * @param {Function} [options.uploadCallbacks.error] - listener for upload error event
-   * @param {Function} [options.uploadCallbacks.load] - listener for upload load completed successfully event
-   * @param {Function} [options.uploadCallbacks.timeout] - listener for upload timeout event
-   * @param {Function} [options.uploadCallbacks.loadend] - listener for upload finished (success or fail) event
    * @param {Object} [options.abortSignal] - an AbortController.AbortSignal object to listen for abort requests
    * @return {*}
    * @private
@@ -238,11 +230,6 @@ class DICOMwebClient {
         }
       }
 
-      // Events triggered while upload progresses.
-      if ('uploadCallbacks' in options) {
-        DICOMwebClient._registerUploadCallbacks(request, options.uploadCallbacks);
-      }
-
       if ('abortSignal' in options && options.abortSignal) {
         const { abortSignal } = options;
 
@@ -285,40 +272,6 @@ class DICOMwebClient {
         request.send();
       }
     });
-  }
-
-  /**
-   * Registers various callbacks for the XMLHttpRequest.upload object. A special loadend listener is added that
-   * will remove all the listeners added once the request has finished.
-   * @param {XMLHttpRequest} request - the request to register the callbacks for
-   * @param {Object} uploadCallbacks - various listeners for the XMLHttpRequest.upload object
-   * @param {Function} [uploadCallbacks.loadstart] - listener for upload start event
-   * @param {Function} [uploadCallbacks.progress] - listener for upload progress event
-   * @param {Function} [uploadCallbacks.abort] - listener for upload aborted event
-   * @param {Function} [uploadCallbacks.error] - listener for upload error event
-   * @param {Function} [uploadCallbacks.load] - listener for upload load completed successfully event
-   * @param {Function} [uploadCallbacks.timeout] - listener for upload timeout event
-   * @param {Function} [uploadCallbacks.loadend] - listener for upload finished (success or fail) event
-   */
- static _registerUploadCallbacks(request, uploadCallbacks) {
-    const uploadCallbackEventNames = ['loadstart', 'progress', 'abort', 'error', 'load', 'timeout', 'loadend'];
-
-    for(const eventName of uploadCallbackEventNames) {
-      if(typeof uploadCallbacks[eventName] === 'function') {
-        request.upload.addEventListener(eventName, uploadCallbacks[eventName]);
-      }
-    }
-
-    const removeCallbacks = () => {
-      request.upload.removeEventListener('loadend', removeCallbacks);
-
-      for(const eventName of uploadCallbackEventNames) {
-        if(typeof uploadCallbacks[eventName] === 'function') {
-          request.upload.removeEventListener(eventName, uploadCallbacks[eventName]);
-        }
-      }
-    };
-    request.upload.addEventListener('loadend', removeCallbacks);    
   }
 
   /**
@@ -778,24 +731,15 @@ class DICOMwebClient {
    * @param {Object} headers - HTTP header fields
    * @param {Array} data - Data that should be stored
    * @param {Function} progressCallback
-   * @param {Object} uploadCallbacks - various listeners for the XMLHttpRequest.upload object
-   * @param {Function} [uploadCallbacks.loadstart] - listener for upload start event
-   * @param {Function} [uploadCallbacks.progress] - listener for upload progress event
-   * @param {Function} [uploadCallbacks.abort] - listener for upload aborted event
-   * @param {Function} [uploadCallbacks.error] - listener for upload error event
-   * @param {Function} [uploadCallbacks.load] - listener for upload load completed successfully event
-   * @param {Function} [uploadCallbacks.timeout] - listener for upload timeout event
-   * @param {Function} [uploadCallbacks.loadend] - listener for upload finished (success or fail) event
    * @param {Object} abortSignal - an AbortController.AbortSignal object to listen for abort requests
    * @private
    * @returns {Promise} Response
    */
-  _httpPost(url, headers, data, progressCallback, withCredentials, uploadCallbacks = {}, abortSignal) {
+  _httpPost(url, headers, data, progressCallback, withCredentials, abortSignal) {
     return this._httpRequest(url, 'post', headers, {
       data,
       progressCallback,
       withCredentials,
-      uploadCallbacks,
       abortSignal,
     });
   }
@@ -1849,14 +1793,6 @@ class DICOMwebClient {
    * @param {Object} options
    * @param {ArrayBuffer[]} options.datasets - DICOM Instances in PS3.10 format
    * @param {String} [options.studyInstanceUID] - Study Instance UID
-   * @param {Object} [options.uploadCallbacks] - various listeners for the XMLHttpRequest.upload object
-   * @param {Function} [options.uploadCallbacks.loadstart] - listener for upload start event
-   * @param {Function} [options.uploadCallbacks.progress] - listener for upload progress event
-   * @param {Function} [options.uploadCallbacks.abort] - listener for upload aborted event
-   * @param {Function} [options.uploadCallbacks.error] - listener for upload error event
-   * @param {Function} [options.uploadCallbacks.load] - listener for upload load completed successfully event
-   * @param {Function} [options.uploadCallbacks.timeout] - listener for upload timeout event
-   * @param {Function} [options.uploadCallbacks.loadend] - listener for upload finished (success or fail) event
    * @param {Object} [options.abortSignal] - an AbortController.AbortSignal object to listen for abort requests
    * @returns {Promise} Response message
    */
@@ -1876,7 +1812,7 @@ class DICOMwebClient {
     };
     const { withCredentials = false } = options;
     return this._httpPost(
-      url, headers, data, options.progressCallback, withCredentials, options.uploadCallbacks, options.abortSignal
+      url, headers, data, options.progressCallback, withCredentials, options.abortSignal
     );
   }
 }

--- a/src/api.js
+++ b/src/api.js
@@ -152,6 +152,7 @@ class DICOMwebClient {
    * @param {Object} headers
    * @param {Object} options
    * @param {Array.<RequestHook>} options.requestHooks - Request hooks.
+   * @param {XMLHttpRequest} [options.request] - if specified, the request to use, otherwise one will be created; useful for adding custom upload and abort listeners/objects
    * @return {*}
    * @private
    */
@@ -159,7 +160,7 @@ class DICOMwebClient {
     const { errorInterceptor, requestHooks } = this;
 
     return new Promise((resolve, reject) => {
-      let request = new XMLHttpRequest();
+      let request = options.request ? options.request : new XMLHttpRequest();
 
       request.open(method, url, true);
       if ('responseType' in options) {
@@ -709,14 +710,17 @@ class DICOMwebClient {
    * @param {Object} headers - HTTP header fields
    * @param {Array} data - Data that should be stored
    * @param {Function} progressCallback
+   * @param {Function} progressCallback
+   * @param {XMLHttpRequest} request - if specified, the request to use, otherwise one will be created; useful for adding custom upload and abort listeners/objects
    * @private
    * @returns {Promise} Response
    */
-  _httpPost(url, headers, data, progressCallback, withCredentials) {
+  _httpPost(url, headers, data, progressCallback, withCredentials, request) {
     return this._httpRequest(url, 'post', headers, {
       data,
       progressCallback,
       withCredentials,
+      request,
     });
   }
 
@@ -1769,6 +1773,7 @@ class DICOMwebClient {
    * @param {Object} options
    * @param {ArrayBuffer[]} options.datasets - DICOM Instances in PS3.10 format
    * @param {String} [options.studyInstanceUID] - Study Instance UID
+   * @param {XMLHttpRequest} [options.request] - if specified, the request to use, otherwise one will be created; useful for adding custom upload and abort listeners/objects
    * @returns {Promise} Response message
    */
   storeInstances(options) {
@@ -1787,7 +1792,7 @@ class DICOMwebClient {
     };
     const { withCredentials = false } = options;
     return this._httpPost(
-      url, headers, data, options.progressCallback, withCredentials,
+      url, headers, data, options.progressCallback, withCredentials, options.request
     );
   }
 }


### PR DESCRIPTION
Replaced the optional uploadCallbacks and AbortSignal objects for storeInstances with an optional XMLHttpRequest.
If present, the request will be used. Otherwise a request will be instantiated as before.
This allows for customizations to be made to the request without cluttering the dicomweb-client code.

Updated the readme with an example for how the changes might get used.