### PR TITLE
Add quality factor to octet-stream mediatype

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -860,6 +860,11 @@ class DICOMwebClient {
       DICOMwebClient._assertMediaTypeIsValid(mediaType);
       let fieldValue = `multipart/related; type="${mediaType}"`;
 
+      if (mediaType.endsWith("octet-stream")) {
+        // Prefer explicit transfer syntax
+        fieldValue += "; q=0.9";
+      }
+
       if (isObject(supportedMediaTypes)) {
         // SupportedMediaTypes is a lookup table that maps Transfer Syntax UID
         // to one or more Media Types


### PR DESCRIPTION
Depending on the IMS implementation, they may return `octet-stream` when `image/jpeg` is available because `octet-stream` appears higher on the list of acceptable media types. This PR adds `q=0.9` to the field value.

Fixes #80 