### PR TITLE
fix(api): multipart array length calculation fixed

### DIFF
--- a/src/message.js
+++ b/src/message.js
@@ -149,10 +149,12 @@ function multipartEncode(
     const contentArray = new Uint8Array(datasetBuffer);
     const contentLength = contentArray.length;
 
-    length += headerLength + contentLength + footerLength;
+    length += headerLength + contentLength;
 
     return contentArray;
   });
+
+  length += footerLength;
 
   // Allocate the array
   const multipartArray = new Uint8Array(length);


### PR DESCRIPTION
i don't think we need to add extra footerLength for each dataset. footer is only set once.