### PR TITLE
[WIP] feat: Add command line tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@ The main motivations for this project is:
 
 Install the [dicomweb-client](https://www.npmjs.com/package/dicomweb-client) package using the `npm` package manager:
 
-```None
+```bash
 npm install dicomweb-client
+# or to install command line, use
+npm install -g dicomweb-client
 ```
 
 ## Building and testing
@@ -33,6 +35,49 @@ cd ~/dicomweb-client
 npm install
 npm run build
 npm test
+# To install the local copy bin files, use:
+npm install -g .
+```
+
+## Command Line
+There are three command line options for interacting with DICOMweb servers: `qido` for querying, `wado` for retrieving, and `stow` for storing.
+
+The supporting code the command line is in `lib` instead of `src` so that it doesn't get included in he default build of the client.
+
+### QIDO
+The qido command line can be used to query for studies, series or instances.  Some examples:
+
+```bash
+# Query for MR studies
+qido studies https://d33do7qe4w26qo.cloudfront.net/dicomweb -q ModalitiesInStudy=MR
+# Query for studies since yesterday
+qido studies https://d33do7qe4w26qo.cloudfront.net/dicomweb -q StudyDate=yesterday-
+
+# Query for series for Study UID 2.25.96975534054447904995905761963464388233 with Modality SR
+qido series  https://d33do7qe4w26qo.cloudfront.net/dicomweb 2.25.96975534054447904995905761963464388233 -q Modality=SR
+
+# Query for patient (only with /patient supporting endpoints):
+qido patient https://d33do7qe4w26qo.cloudfront.net/dicomweb -q PatientID=M1
+
+```
+
+### WADO
+The wado commandline can be used to retrieve part 10 or metadata endpoints.  It will save them to a directory
+in the DICOMweb structure.  This assumes that the QIDO queries are available to figure out the layout
+
+```bash
+# Retrieve metadata related study (metadata at series level, image data and bulkdata)
+# Default output is to user home directory (~) `~/dicomweb/studies/<studyUID>/....`
+wado metadata  https://d33do7qe4w26qo.cloudfront.net/dicomweb 2.25.96975534054447904995905761963464388233 
+```
+
+### STOW
+The STOW command line can be used to store part 10 or metadata to the remote server.
+
+```bash
+# Store part 10 DICOM to the given destination server.
+```
+stow part10 https://d33do7qe4w26qo.cloudfront.net/dicomweb file1.dcm ... fileN.dcm 
 ```
 
 ## Usage

--- a/bin/qido.js
+++ b/bin/qido.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+
+const { Command } = require('commander');
+const program = new Command();
+
+program
+  .name('qido')
+  .description('CLI to query a study')
+  .version('0.0.1');
+
+  
+program.command('patient')
+.description('Queries for studies of a given study')
+.argument('<string>', 'URL to query against in http:.../studies format')
+.action((str, options) => {
+  console.log('Query patients', str);
+});
+
+program.command('studies')
+  .description('Queries for studies of a given study')
+  .argument('<string>', 'URL to query against in http:.../studies format')
+  .action((str, options) => {
+    console.log('Query studies', str);
+  });
+
+program.command('series')
+  .description('Queries for series of a given study')
+  .argument('<string>', 'URL to query against in http:.../studies format')
+  .action((str, options) => {
+    console.log('query series', str);
+  });
+
+program.parse();

--- a/bin/stow.js
+++ b/bin/stow.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+console.log("wadors retrieve studies/images")
+const { Command } = require('commander');
+const program = new Command();
+
+program
+  .name('stow')
+  .description('CLI to store part 10 data to a DICOMweb server')
+  .version('0.0.1');
+
+program.command('part10')
+  .description('Fetch a study using series metadata/bulkdata/image data retrieves')
+  .argument('<string>', 'URL to store to DICOMweb in http:.../studies format')
+  .option('-d, --directory <outputDirectory>', 'Fetch data to directory')
+  .action((str, options) => {
+    console.log('Store metadata to', str);
+  });
+
+program.parse();

--- a/bin/wado.js
+++ b/bin/wado.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+
+const { Command } = require('commander');
+const program = new Command();
+
+program
+  .name('wado')
+  .description('CLI to fetch studies via WADO RS')
+  .version('0.0.1');
+
+program.command('metadata')
+  .description('Fetch a study using series metadata/bulkdata/image data retrieves')
+  .argument('<string>', 'URL to extra in http:.../studies/<studyUID> format')
+  .option('-d, --directory <outputDirectory>', 'Fetch data to directory')
+  .action((str, options) => {
+    console.log('Retrieve metadata from', str);
+  });
+
+program.parse();

--- a/dicomweb-client.code-workspace
+++ b/dicomweb-client.code-workspace
@@ -1,0 +1,8 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {}
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,16 @@
     "type": "git",
     "url": "git+https://github.com/dcmjs-org/dicomweb-client.git"
   },
+  "directories": [
+    "bin", 
+    "lib",
+    "src"
+  ],
+  "bin": {
+    "stow": "bin/stow.js",
+    "qido": "bin/qido.js",
+    "wado": "bin/wado.js"
+  },
   "keywords": [
     "dicom",
     "dcmjs",
@@ -48,5 +58,8 @@
     "rollup": "^0.63.2",
     "rollup-plugin-babel": "^4.0.3",
     "typescript": "^4.8.4"
+  },
+  "dependencies": {
+    "commander": "^12.1.0"
   }
 }


### PR DESCRIPTION
Add command line tools to access DICOMweb servers.

qido studies URL -q Query
wado metadata URL STUDYUID
stow part10 URL DICOM_FILES

These commands lines are defined in this PR, but are not yet functional.  Want to check how they look before going to far.