### PR TITLE
fix(message): Fixed bug in final length calculation in Multipart Encoded

### DIFF
--- a/src/message.js
+++ b/src/message.js
@@ -149,10 +149,12 @@ function multipartEncode(
     const contentArray = new Uint8Array(datasetBuffer);
     const contentLength = contentArray.length;
 
-    length += headerLength + contentLength + footerLength;
+    length += headerLength + contentLength
 
     return contentArray;
   });
+
+  length += footerLength;
 
   // Allocate the array
   const multipartArray = new Uint8Array(length);


### PR DESCRIPTION
Previously, footerLength was added as many times as the number of contents, but we changed it to adding it only once at the end.